### PR TITLE
Add raw serial support

### DIFF
--- a/controller.py
+++ b/controller.py
@@ -133,6 +133,9 @@ elif commandArgs.type == "parallaxy":
 elif commandArgs.type == "blank":
             import blank_interface as interface
 
+elif commandArgs.type == "serial":
+            import serial_interface as interface
+
 elif commandArgs.type == "sexbot":
             import sexbot_interface as interface
             interface.init()

--- a/serial_interface.py
+++ b/serial_interface.py
@@ -1,0 +1,12 @@
+import serial
+import robot_util
+
+try:
+    ser = serial.Serial(port='/dev/ttyUSB0', baudrate=9600)
+except Exception as e:
+    print("Serial Error, Failed to connect.", e)
+
+def handleCommand(command, keyPosition):
+    global lastCommand
+    print("Sending command to serial device")
+    ser.write(command.encode())


### PR DESCRIPTION
Adding raw serial support to be able to use any serial device if needed.

Tested this on windows, it uses pyserial, so it also works on Raspberry Pi